### PR TITLE
User-friendly -p option for upload

### DIFF
--- a/src/main/java/com/joyent/manta/archiver/MantaArchiverCLI.java
+++ b/src/main/java/com/joyent/manta/archiver/MantaArchiverCLI.java
@@ -24,14 +24,14 @@ import org.apache.commons.lang3.BooleanUtils;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 
-import javax.crypto.SecretKey;
-import javax.crypto.spec.SecretKeySpec;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.NoSuchAlgorithmException;
 import java.util.List;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
 
 import static com.joyent.manta.archiver.MantaArchiverCLI.MantaSubCommand.CommandLogLevel.DEBUG;
 import static com.joyent.manta.archiver.MantaArchiverCLI.MantaSubCommand.CommandLogLevel.INFO;
@@ -377,12 +377,15 @@ public class MantaArchiverCLI {
                 index = "1", description = "directory in Manta to upload files to")
         private String mantaDirectory;
 
+        @CommandLine.Option(names = {"-p", "--mkdirp"})
+        private boolean mkdirp;
+
         @Override
         public void run() {
             final Path localRoot = findLocalPath(localDirectory);
 
             MantaTransferClient mantaTransferClient = new MantaTransferClient(
-                    MANTA_CLIENT_SUPPLIER, mantaDirectory);
+                    MANTA_CLIENT_SUPPLIER, mantaDirectory, localRoot, mkdirp);
 
             try (TransferManager manager = new TransferManager(mantaTransferClient,
                     localRoot)) {


### PR DESCRIPTION
It's a hack but it means users don't have to install `node-manta` to get started.

The presence of `singleFile` is a big distraction and it should be removed in the future, it's only ever used in a single place and could've been calculated later, plus the layout of the `MantaTransferClient` makes it cumbersome to initialize. It seems even more pointless when `ArchiveSubCommand#findLocalPath` rejects non-directories and kills the CLI with `Local directory path is not a directory`.